### PR TITLE
Fix broken build due to flake8-docstrings error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,14 @@ install: pip install \
   flake8-quotes \
   "pydocstyle<4.0.0"
   tox-travis
+
 before_script:
   - coverage erase
+
 script:
   - flake8
   - tox
+
 after_success:
   - coverage combine
   - coverage report

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,17 @@ cache: pip
 sudo: false
 python:
  - "3.6"
+
+# pydocstyle pinned due to build error (used by flake8-docstrings). See:
+# - https://gitlab.com/pycqa/flake8-docstrings/issues/36
+# - https://github.com/PyCQA/pydocstyle/issues/375
 install: pip install \
   codacy-coverage \
   coverage flake8 \
   flake8-docstrings \
   flake8-per-file-ignores \
   flake8-quotes \
+  "pydocstyle<4.0.0"
   tox-travis
 before_script:
   - coverage erase


### PR DESCRIPTION
Temporarily pin pydocstyle to < 4.0.0 (required by flake8-docstrings)