### PR TITLE
Update page.py

### DIFF
--- a/simple_pages/admin/page.py
+++ b/simple_pages/admin/page.py
@@ -2,7 +2,7 @@
 
 from django import forms
 from django.contrib.admin import register, ModelAdmin
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from ..models import Page
 from ..widgets import CodeMirrorTextarea


### PR DESCRIPTION
import translation function name changed 

https://forum.djangoproject.com/t/importerror-cannot-import-name-ugettext-lazy-from-django-utils-translation/10943/3